### PR TITLE
Add Japanese README for Atuin Desktop

### DIFF
--- a/README_JA.md
+++ b/README_JA.md
@@ -1,0 +1,133 @@
+<p align="center">
+ <picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/atuinsh/atuin/assets/53315310/13216a1d-1ac0-4c99-b0eb-d88290fe0efd">
+  <img alt="Atuin Desktop" src="https://github.com/atuinsh/atuin/assets/53315310/08bc86d4-a781-4aaa-8d7e-478ae6bcd129">
+</picture>
+</p>
+
+<h1 align="center">Atuin Desktop</h1>
+
+<p align="center">
+  <em>実行可能なRunbook。実際のターミナルワークフローに対応した、ローカルファーストで実行可能なRunbookエディター。Atuin Desktopはドキュメントのように見えますが、ターミナルのように動作します。</em>
+</p>
+
+
+<p align="center">
+  <a href="https://github.com/atuinsh/desktop/releases">download</a> | <a href="https://man.atuin.sh">documentation</a> | <a href="https://hub.atuin.sh/">hub</a> | <a href="https://discord.gg/Fq8bJSKPHh">discord</a>
+</p>
+
+
+<p align="center">
+ <picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://man.atuin.sh/images/atuin-desktop-ss-dark.png">
+  <img alt="Atuin Desktop" src="https://man.atuin.sh/images/atuin-desktop-ss-light.png">
+</picture>
+</p>
+
+（[English](README.md), [日本語](README-ja.md)）
+
+## 🚀 オープン ベータ
+
+Atuin Desktopは**オープン ベータ中**です。皆様からのフィードバックを積極的に収集し、実際の使用状況に基づいてエクスペリエンスを改善しています。
+
+[アナウンス ポスト](https://blog.atuin.sh/atuin-desktop-open-source/)を読む。
+
+## Atuin Desktopとは何ですか?
+
+ほとんどのインフラは、何か問題が起きたときに誰かが思い出す5つのコマンドで支えられています。ドキュメントは古く（そもそも存在するかどうかさえも）、真の答えはSlackのスレッドに埋もれたり、Notionで散らかったり、誰かのシェル履歴に閉じ込められたりしています。
+
+Atuin Desktopは、ドキュメントと自動化のギャップを埋める実行可能なRunbookを作成することでこの問題を解決します:
+
+- **コンテキストスイッチをなくす**: シェルコマンド、データベースクエリ、HTTPリクエストを1か所にまとめる
+- **ドキュメント腐らせない**: 直接実行して関連性を保つ
+- **再利用可能な自動化**: Jinjaスタイルのテンプレートを使用した動的なRunbook
+- **瞬時のリコール**: 実際のシェル履歴からのオートコンプリート
+- **ローカルファースト、CRDT駆動**: ターミナルで実行できるものはRunbookでも実行できる
+- **同期と共有**: Atuin Hubを使用してデバイスやチーム間でRunbookを最新の状態に保つ
+
+## 主な特徴
+
+### 🔧 組み込み実行
+- インターフェース内で直接実行されるターミナルブロック
+- ライブクエリ用のデータベースクライアント
+- Prometheusチャートと監視統合
+
+### 📚 生きたドキュメント
+- 実行可能なRunbook
+- 古いドキュメントからのコピーペーストは不要
+- チームが実際に使用できるワークフロー
+
+### 🔄 動的テンプレーティング
+- 再利用可能なロジックのためのJinjaスタイルのテンプレーティング
+- 変数の置換と条件付きロジック
+- 異なる環境のためのパラメータ化されたワークフロー
+
+### 🏛 ローカルファーストアーキテクチャ
+- CRDT駆動のコラボレーション
+- オフラインで動作し、接続時に同期
+
+## ユースケース
+
+既に導入しているチームはAtuin Desktopを以下の目的で使用しています:
+
+- **リリース管理**: 実際に実行される自動化されたリリースチェックリスト
+- **インフラストラクチャの移行**: 安全で再現性のある移行ワークフロー
+- **環境管理**: 自信を持ってステージングとプロダクションを立ち上げる
+- **データベース操作**: コラボレーティブなライブクエリ管理
+- **インシデント対応**: 障害発生時のRunbook
+
+## はじめましょう
+
+1. ご利用のプラットフォームにあわせたパッケージを [リリースページ](https://github.com/atuinsh/desktop/releases)からダウンロード
+2. [Atuin Hub](https://hub.atuin.sh/)でアカウントにサインアップ
+3. Atuin Desktopに[ログイン](https://man.atuin.sh/hub/getting-started/)し、最初のRunbookを作成
+
+## フィードバックとサポート
+
+私たちはベータ版の期間中にフィードバックを積極的に求めています！このリポジトリを使用して、以下のことを行ってください。
+
+### 🐛 問題の報告
+- バグを見つけましたか？ [問題を開く](../../issues/new?template=bug_report.md)
+- OS、Atuin Desktopのバージョン、再現手順を含めてください
+
+### 💡 機能リクエスト
+- アイデアがありますか？ [機能リクエストを提出](../../issues/new?template=feature_request.md)
+- ワークフローについて教えてください。Atuin Desktopがどのようにサポートできるかを教えてください
+
+### 💬 一般的な議論
+
+使用に関する質問がありますか？ [ディスカッションを開始](https://forum.atuin.sh)
+
+## ロードマップ
+
+### 今後の予定
+- **強化された統合**: より多くのデータベースクライアント、監視ツール、API
+- **履歴からRunbookへ**: シェル履歴から自動的にRunbookを生成
+
+## コミュニティ
+
+- **Blog**: [blog.atuin.sh](https://blog.atuin.sh)
+- **Discord**: [コミュニティに参加](https://discord.gg/Fq8bJSKPHh)
+- **Twitter**: [@atuinsh](https://twitter.com/atuinsh)
+- **Bluesky**: [@atuin.sh](https://bsky.app/profile/atuin.sh)
+- **Website**: [atuin.sh](https://atuin.sh)
+
+## 関連するプロジェクト
+
+- **[Atuin CLI](https://github.com/atuinsh/atuin)**: 同期、検索、統計機能を備えた魔法のシェル履歴
+
+## License
+
+Copyright 2025 Atuin, Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README_JA.md
+++ b/README_JA.md
@@ -24,7 +24,7 @@
 </picture>
 </p>
 
-（[English](README.md), [日本語](README-ja.md)）
+（[English](README.md), [日本語](README_JA.md)）
 
 ## 🚀 オープン ベータ
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,111 +1,111 @@
 ---
-description: Transform operational workflows into collaborative runbooks that execute database queries, API calls, and scripts.
+description: 操作ワークフローを、データベースクエリ、API呼び出し、スクリプトを実行する共同作業可能なランブックに変換します。
 ---
 
-# :material-home: Welcome to Atuin Desktop
+# :material-home: Atuin Desktopへようこそ
 
-Transform your operational workflows from scattered terminal commands into powerful, collaborative runbooks that actually execute.
+散在したターミナルコマンドからなる操作ワークフローを、実際に実行可能な強力で共同作業もできるランブックに変換します。
 
-## What is Atuin Desktop?
+## Atuin Desktopとは？
 
-Atuin Desktop bridges the gap between documentation and automation. Create **executable runbooks** that combine rich documentation with live database queries, API calls, scripts, and terminal sessions - all in a collaborative, block-based editor.
+Atuin Desktopは、ドキュメンテーションと自動化の間のギャップを埋めます。豊富なドキュメンテーションと、ライブのデータベースクエリ、API呼び出し、スクリプト、ターミナルセッションを組み合わせた**実行可能なランブック**を作成します - すべて共同作業可能なブロックベースのエディタで行えます。
 
-!!! info "Early Beta"
-    We're still in early beta and things are changing fast! Your feedback helps shape the future of operational documentation.
+!!! info "早期ベータ版"
+    私たちはまだ早期ベータ版であり、物事は急速に変化しています！皆様のフィードバックが、操作ドキュメンテーションの未来を形作る助けとなります。
 
-## :material-lightning-bolt: Why Atuin Desktop?
+## :material-lightning-bolt: なぜAtuin Desktopなのか？
 
-**From Terminal to Team Workflow**  
-Stop copy-pasting commands from docs. Build runbooks that execute database queries, run scripts, make API calls, and manage infrastructure - then share them with your team.
+**ターミナルからチームのワークフローへ**
+ドキュメントからコマンドをコピー＆ペーストするのはやめましょう。データベースクエリの実行、スクリプトの実行、API呼び出し、インフラ管理を行うランブックを構築し、チームと共有しましょう。
 
-**Intuitive Block-Based Editor**  
-Drag, drop, and rearrange content with a flexible editor designed specifically for operational workflows and automation.
+**直感的なブロックベースのエディタ**
+操作ワークフローと自動化のために特別に設計された柔軟なエディタで、コンテンツをドラッグ、ドロップ、再配置できます。
 
-**Real-time Collaboration**  
-Work together on incident response, deployment procedures, and maintenance tasks with live editing and execution.
+**リアルタイムコラボレーション**
+ライブ編集と実行により、インシデント対応、デプロイ手順、メンテナンスタスクで協力して作業できます。
 
-## :material-rocket-launch: Quick Start
+## :material-rocket-launch: クイックスタート
 
-Ready to create your first runbook?
+最初のランブックを作成する準備はできましたか？
 
 <div class="grid cards" markdown>
 
--   :material-book-open:{ .lg .middle } **Getting Started Guide**
+-   :material-book-open:{ .lg .middle } **入門ガイド**
 
     ---
 
-    Learn the basics of runbooks, blocks, and creating your first automated workflow.
+    ランブック、ブロックの基本、そして最初の自動化ワークフローの作成方法を学びます。
 
-    [:octicons-arrow-right-24: Get Started](getting-started.md)
+    [:octicons-arrow-right-24: 始める](getting-started.md)
 
--   :material-cube:{ .lg .middle } **Explore Blocks**
+-   :material-cube:{ .lg .middle } **ブロックを探る**
 
     ---
 
-    Discover all the interactive components you can add to your runbooks.
+    ランブックに追加できるすべてのインタラクティブコンポーネントを発見してください。
 
-    [:octicons-arrow-right-24: Browse Blocks](blocks/index.md)
+    [:octicons-arrow-right-24: ブロックを閲覧する](blocks/index.md)
 
 </div>
 
-## :material-download: Installation
+## :material-download: インストール
 
-### Desktop Application
+### デスクトップアプリケーション
 
-Download Atuin Desktop from our releases page 
+リリースページからAtuin Desktopをダウンロードしてください。
 
-### CLI Integration
+### CLI統合
 
-Atuin Desktop works best with the Atuin History CLI for enhanced terminal integration:
+Atuin Desktopは、ターミナル統合を強化するためにAtuin History CLIと組み合わせると最適に動作します。
 
 ```bash
 curl --proto '=https' --tlsv1.2 -LsSf https://setup.atuin.sh | sh
 ```
 
-[:octicons-link-external-24: Full CLI Documentation](https://docs.atuin.sh)
+[:octicons-link-external-24: 完全なCLIドキュメント](https://docs.atuin.sh)
 
-## :material-compass: Explore the Docs
+## :material-compass: ドキュメントを探る
 
 <div class="grid cards" markdown>
 
--   :material-database:{ .lg .middle } **Database Blocks**
+-   :material-database:{ .lg .middle } **データベースブロック**
 
     ---
 
-    Connect to MySQL, PostgreSQL, ClickHouse, and SQLite databases.
+    MySQL、PostgreSQL、ClickHouse、SQLiteデータベースに接続します。
 
-    [:octicons-arrow-right-24: Database Blocks](blocks/databases/index.md)
+    [:octicons-arrow-right-24: データベースブロック](blocks/databases/index.md)
 
--   :material-play:{ .lg .middle } **Executable Blocks**
-
-    ---
-
-    Run scripts, execute commands, and automate workflows.
-
-    [:octicons-arrow-right-24: Executable Blocks](blocks/executable/README.md)
-
--   :material-code-braces:{ .lg .middle } **Templating**
+-   :material-play:{ .lg .middle } **実行可能ブロック**
 
     ---
 
-    Create dynamic, reusable runbooks with variables.
+    スクリプトの実行、コマンドの実行、ワークフローの自動化を行います。
 
-    [:octicons-arrow-right-24: Templating Guide](templating.md)
+    [:octicons-arrow-right-24: 実行可能ブロック](blocks/executable/README.md)
+
+-   :material-code-braces:{ .lg .middle } **テンプレート**
+
+    ---
+
+    変数を使用して、動的で再利用可能なランブックを作成します。
+
+    [:octicons-arrow-right-24: テンプレートガイド](templating.md)
 
 -   :material-hub:{ .lg .middle } **Atuin Hub**
 
     ---
 
-    Share and collaborate on runbooks with your team.
+    チームでランブックを共有し、共同作業を行います。
 
-    [:octicons-arrow-right-24: Collaboration Features](hub/getting-started.md)
+    [:octicons-arrow-right-24: コラボレーション機能](hub/getting-started.md)
 
 </div>
 
-## Common Use Cases
+## 一般的な使用例
 
-Whether you're documenting **incident response procedures**, **onboarding new engineers**, **automating deployment workflows**, or **managing infrastructure maintenance**, Atuin Desktop makes it easy to structure and execute operational knowledge.
+**インシデント対応手順**の文書化、**新人エンジニアのオンボーディング**、**デプロイメントワークフローの自動化**、**インフラストラクチャメンテナンスの管理**など、Atuin Desktopは操作知識を構造化し実行するのを容易にします。
 
 ---
 
-**Ready to get started?** Jump into our [Getting Started Guide](getting-started.md) to create your first executable runbook!
+**始める準備はできましたか？** [入門ガイド](getting-started.md)に飛び込んで、最初の実行可能なランブックを作成しましょう！


### PR DESCRIPTION
Introduces README_JA.md with a full Japanese translation of the Atuin Desktop documentation, including features, usage instructions, feedback channels, and licensing information.Introduces README_JA.md with a full Japanese translation of the Atuin Desktop documentation, including features, usage instructions, feedback channels, and licensing information.